### PR TITLE
Dirty data

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -31,7 +31,7 @@ var data2 = `{
 }`
 
 // TestUnmarshalData tests that we now properly unmarshal both forms
-// fo the data.
+// of the data.
 func TestUnmarshalData(t *testing.T) {
 	var d dumpFormat
 

--- a/data_test.go
+++ b/data_test.go
@@ -16,17 +16,35 @@ func init() {
 	os.Setenv("PG_SSL", "disable")
 }
 
+// struct w/ regular encoding
 var data1 = `{
     "name" : "Lerner 3",
     "client_count" : 70,
     "parent_id" : 84
 }`
 
+// struct w/ string-encoded numbers
 var data2 = `{
     "name" : "Lerner 3",
     "client_count" : "70",
     "parent_id" : "84"
 }`
+
+// TestUnmarshalData tests that we now properly unmarshal both forms
+// fo the data.
+func TestUnmarshalData(t *testing.T) {
+	var d dumpFormat
+
+	err := json.Unmarshal([]byte(data1), &d)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal data with integers => {%s}", err)
+	}
+
+	err = json.Unmarshal([]byte(data2), &d)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal data with strings => {%s}", err)
+	}
+}
 
 var testingData1 = `{
   "152" : {
@@ -103,20 +121,6 @@ var expectedData = []dumpFormat{
 		ParentID:    103,
 		ParentName:  "Butler",
 	},
-}
-
-func TestUnmarshalData(t *testing.T) {
-	var d dumpFormat
-
-	err := json.Unmarshal([]byte(data1), &d)
-	if err != nil {
-		t.Fatalf("Failed to unmarshal data with integers => {%s}", err)
-	}
-
-	err = json.Unmarshal([]byte(data2), &d)
-	if err != nil {
-		t.Fatalf("Failed to unmarshal data with strings => {%s}", err)
-	}
 }
 
 // TestParseData parses the raw data in `testingData` and confirms that it

--- a/data_test.go
+++ b/data_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 	"time"
@@ -15,7 +16,19 @@ func init() {
 	os.Setenv("PG_SSL", "disable")
 }
 
-var testingData = `{
+var data1 = `{
+    "name" : "Lerner 3",
+    "client_count" : 70,
+    "parent_id" : 84
+}`
+
+var data2 = `{
+    "name" : "Lerner 3",
+    "client_count" : "70",
+    "parent_id" : "84"
+}`
+
+var testingData1 = `{
   "152" : {
     "name" : "Lerner 3",
     "client_count" : 70,
@@ -35,6 +48,29 @@ var testingData = `{
     "name" : "Butler Library 2",
     "client_count" : 412,
     "parent_id" : 103
+  }
+}`
+
+var testingData2 = `{
+  "152" : {
+    "name" : "Lerner 3",
+    "client_count" : "70",
+    "parent_id" : "84"
+  },
+  "131" : {
+    "name" : "Butler Library 3",
+    "client_count" : "328",
+    "parent_id" : "103"
+  },
+  "155" : {
+    "name" : "JJ's Place",
+    "client_count" : "90",
+    "parent_id" : "75"
+  },
+  "130" : {
+    "name" : "Butler Library 2",
+    "client_count" : "412",
+    "parent_id" : "103"
   }
 }`
 
@@ -69,26 +105,42 @@ var expectedData = []dumpFormat{
 	},
 }
 
+func TestUnmarshalData(t *testing.T) {
+	var d dumpFormat
+
+	err := json.Unmarshal([]byte(data1), &d)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal data with integers => {%s}", err)
+	}
+
+	err = json.Unmarshal([]byte(data2), &d)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal data with strings => {%s}", err)
+	}
+}
+
 // TestParseData parses the raw data in `testingData` and confirms that it
 // correctly configures all data fields.
 func TestParseData(t *testing.T) {
-	data, err := parseData(time.Time{}, []byte(testingData))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// make sure that the parsed data is in the expected data
-	expected := func(d dumpFormat, t *testing.T) {
-		for _, e := range expectedData {
-			if d == e {
-				return
-			}
+	for _, dataset := range []string{testingData1, testingData2} {
+		data, err := parseData(time.Time{}, []byte(dataset))
+		if err != nil {
+			t.Fatal(err)
 		}
-		t.Errorf("No match in expected data for %#v\n", d)
-	}
 
-	// n^2 because n == 4....
-	for _, d := range data {
-		expected(d, t)
+		// make sure that the parsed data is in the expected data
+		expected := func(d dumpFormat, t *testing.T) {
+			for _, e := range expectedData {
+				if d == e {
+					return
+				}
+			}
+			t.Errorf("No match in expected data for %#v\n", d)
+		}
+
+		// n^2 because n == 4....
+		for _, d := range data {
+			expected(d, t)
+		}
 	}
 }

--- a/test_data/2014-10-31-15-00.json
+++ b/test_data/2014-10-31-15-00.json
@@ -1,0 +1,112 @@
+{
+  "152" : {
+    "name" : "Lerner 3",
+    "client_count" : "24",
+    "parent_id" : "84"
+  },
+  "131" : {
+    "name" : "Butler Library 3",
+    "client_count" : "174",
+    "parent_id" : "103"
+  },
+  "155" : {
+    "name" : "JJ's Place",
+    "client_count" : "69",
+    "parent_id" : "75"
+  },
+  "130" : {
+    "name" : "Butler Library 2",
+    "client_count" : "262",
+    "parent_id" : "103"
+  },
+  "139" : {
+    "name" : "Lehman Library 2",
+    "client_count" : "24",
+    "parent_id" : "79"
+  },
+  "154" : {
+    "name" : "Lerner 5",
+    "client_count" : "49",
+    "parent_id" : "84"
+  },
+  "144" : {
+    "name" : "Starr East Asian Library",
+    "client_count" : "97",
+    "parent_id" : "62"
+  },
+  "125" : {
+    "name" : "John Jay Dining Hall",
+    "client_count" : "13",
+    "parent_id" : "75"
+  },
+  "23" : {
+    "name" : "Uris/Watson Library",
+    "client_count" : "274",
+    "parent_id" : "2"
+  },
+  "133" : {
+    "name" : "Butler Library 5",
+    "client_count" : "65",
+    "parent_id" : "103"
+  },
+  "147" : {
+    "name" : "Architectural and Fine Arts Library 1",
+    "client_count" : "11",
+    "parent_id" : "146"
+  },
+  "149" : {
+    "name" : "Architectural and Fine Arts Library 3",
+    "client_count" : "58",
+    "parent_id" : "146"
+  },
+  "85" : {
+    "name" : "Roone Arledge Auditorium",
+    "client_count" : "38",
+    "parent_id" : "84"
+  },
+  "134" : {
+    "name" : "Butler Library 6",
+    "client_count" : "58",
+    "parent_id" : "103"
+  },
+  "138" : {
+    "name" : "Butler Library stk",
+    "client_count" : "16",
+    "parent_id" : "103"
+  },
+  "153" : {
+    "name" : "Lerner 4",
+    "client_count" : "77",
+    "parent_id" : "84"
+  },
+  "145" : {
+    "name" : "Science and Engineering Library",
+    "client_count" : "68",
+    "parent_id" : "15"
+  },
+  "151" : {
+    "name" : "Lerner 2",
+    "client_count" : "57",
+    "parent_id" : "84"
+  },
+  "132" : {
+    "name" : "Butler Library 4",
+    "client_count" : "107",
+    "parent_id" : "103"
+  },
+  "148" : {
+    "name" : "Architectural and Fine Arts Library 2",
+    "client_count" : "89",
+    "parent_id" : "146"
+  },
+  "140" : {
+    "name" : "Lehman Library 3",
+    "client_count" : "145",
+    "parent_id" : "79"
+  },
+  "150" : {
+    "name" : "Lerner 1",
+    "client_count" : "4",
+    "parent_id" : "84"
+  }
+}


### PR DESCRIPTION
This PR adds more flexibility to the parsing of wireless data to handle both the encodings that CUIT provides us. This allows the `parent_id` and `client_count` to be either string or integer encoded.

This is done by implementing the [Unmarshaler](http://golang.org/pkg/encoding/json/#Unmarshaler) interface for the `dumpFormat` struct. This overrides the normal generic `Unmarshal` method used.
Our `Unmarshal` method checks the type of the `parent_id` and `client_count` field and properly parses it.

reviewers: @RaymondXu, @danrschlosser 

Closes #7 